### PR TITLE
29:修复了持续定位时cbCurrentLocation回调不生效的问题

### DIFF
--- a/第三方SDK/uexBaiduMap(3.0)/README.md
+++ b/第三方SDK/uexBaiduMap(3.0)/README.md
@@ -2409,6 +2409,7 @@ uexBaiduMap.cbBusLineSearchResult = function(data){
 
 | 历史发布版本 | iOS更新 | 安卓更新 |
 | ----- | ----- | ----- |
+| 3.2.29| |修复了持续定位时cbCurrentLocation回调不生效的问题|
 | 3.2.28| |修复open接口传入的中心点不生效的问题|
 | 3.2.27| |修改插件，使其支持config配置APIKey|
 | 3.1.26| |去掉插件中的ActivityGroup,配合引擎升级|


### PR DESCRIPTION
29:修复了持续定位时cbCurrentLocation回调不生效的问题
